### PR TITLE
fix: リソースサーバーURLから/mcpサフィックスを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
     "wrangler": "^4.4.0"
+  },
+  "volta": {
+    "node": "23.11.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,8 @@ const createOAuthMetadata = (env: Env): OAuthMetadata => {
 
 // リソースサーバーの識別子（audienceとして使用）
 const getResourceServerUrl = (workerUrl: string, env: Env) => {
-  return env.MCP_SERVER_URL || `${workerUrl}/mcp`;
+  // return env.MCP_SERVER_URL || `${workerUrl}/mcp`;
+  return env.MCP_SERVER_URL || `${workerUrl}`;
 };
 
 const createTokenVerifier = (workerUrl: string, env: Env) => {
@@ -172,6 +173,7 @@ const createTokenVerifier = (workerUrl: string, env: Env) => {
 
         if (isJWT) {
           // JWTの場合
+          console.log("JWT token detected");
           try {
             return await verifyJWT(token);
           } catch (jwtError) {
@@ -179,6 +181,7 @@ const createTokenVerifier = (workerUrl: string, env: Env) => {
             return await verifyOpaqueToken(token);
           }
         } else {
+          console.log("opaque token detected");
           // JWT形式でない場合はopaque tokenとして扱う
           return await verifyOpaqueToken(token);
         }


### PR DESCRIPTION
## Summary
- リソースサーバーURLの生成時に`/mcp`サフィックスを追加しないように修正
- JWTとopaqueトークンの検出時にデバッグログを追加
- package.jsonにVolta設定を追加（Node.js v23.11.1）

## Test plan
- [ ] MCPサーバーへの接続が正常に動作することを確認
- [ ] JWT認証が正常に動作することを確認
- [ ] Opaqueトークン認証が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)